### PR TITLE
Make README example runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,16 @@ go func() {
 		recurse,
 		skipDotFilesAndFolders,
 		checkIntervalInSeconds
-	).Start()
+	)
+	
+	folderWatcher.Start()
 
 	for folderWatcher.IsRunning() {
 
 		select {
 
-		case <-folderWatcher.New():
-			fmt.Println("New items detected")
-
 		case <-folderWatcher.Modified():
-			fmt.Println("Modified items detected")
+			fmt.Println("New or modified items detected")
 
 		case <-folderWatcher.Moved():
 			fmt.Println("Items have been moved")


### PR DESCRIPTION
A few things have changed since the original docs were written, which render the file non-runnable:
- `Start()` [doesn't have a return value](https://github.com/andreaskoch/go-fswatch/blob/ecea47604a702853c881a7dd161fead47ce8467f/folder.go#L96), so it can't be assigned
- `New()` doesn't actually exist - [modifed is set for new items](https://github.com/andreaskoch/go-fswatch/blob/ecea47604a702853c881a7dd161fead47ce8467f/folder.go#L171-L176)

With these changes the example code will compile.
